### PR TITLE
Style50install

### DIFF
--- a/style50.md
+++ b/style50.md
@@ -155,7 +155,7 @@ If you'd like to install `style50` on your own Mac or PC, so that you can check 
 - If running Mac OS, you already have one! Open **Applications > Utilities > Terminal**.
 - If running Windows, you'll need to install the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about), which is only supported on Windows 10. Once installed, [run `bash`](https://blogs.windows.com/buildingapps/2016/03/30/run-bash-on-ubuntu-on-windows/).
 
-To install `style50` within that command-line environment:
+To install `style50` on Ubuntu or on Windows Subsystem for Linux and Ubuntu, open a Terminal:
 
 1. [Install Python](https://www.python.org/downloads/) 2.7 or higher, if not already installed.
 
@@ -183,6 +183,38 @@ To install `style50` within that command-line environment:
    ```
 
    to install CS50's own compiled version of `astyle`.
+
+
+To install `style50` on Mac OS X (tested on 10.15.3 Catalina) using HomeBrew, open a Terminal:
+
+1. [Install HomeBrew](https://brew.sh) if not already installed, by running:
+
+   ```
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+   ```
+
+2. Install python and pip using HomeBrew, with the following command:
+
+    ```
+    brew install python
+    ```
+    
+3. Install style50 using pip, with the following command:
+    
+    ```
+    pip3 install style50
+    ```
+
+4. Install [Artistic Style 3.0](http://astyle.sourceforge.net/) using HomeBrew, with the following command:
+    ```
+    brew install astyle
+    ```
+
+5. Install libmagic using HomeBrew, with the following command:
+    ```
+    brew install libmagic
+    ```
+
 
 ## Upgrading
 

--- a/style50.md
+++ b/style50.md
@@ -159,10 +159,11 @@ To install `style50` on Ubuntu or on Windows Subsystem for Linux and Ubuntu, ope
 
 1. [Install Python](https://www.python.org/downloads/) 2.7 or higher, if not already installed.
 
-1. Install `pip`, as via
+1. Install `pip`, if you did not install Python via the python.org package or it was not included with your system, as via
 
    ```
-   sudo easy_install pip
+   curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+   python get-pip.py
    ```
 
    if not already installed.

--- a/style50.md
+++ b/style50.md
@@ -159,7 +159,7 @@ To install `style50` on Ubuntu or on Windows Subsystem for Linux and Ubuntu, ope
 
 1. [Install Python](https://www.python.org/downloads/) 2.7 or higher, if not already installed.
 
-1. Install `pip`, if you did not install Python via the python.org package or it was not included with your system, as via
+1. Install `pip`, if you did not install Python via the python.org package or pip was not included with your system, as via
 
    ```
    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
This PR provides instructions for installation of style50, and its required dependencies, on Mac OS using HomeBrew and corrects the depreciated easy_install method of installing pip.

**A couple of notes:**

On the Mac OS installation methods:

Added installation instructions for MacOS for style50. I decided to use HomeBrew for the installation because of the PyPa warning against installing PIP on the OS's distribution of python and because the easiest way to install libmagic and astyle is through HomeBrew. 

If we were to use the OS instance of python we would need to either provide more complicated instructions to install libmagic and astyle OR provide instructions on creating a symlink to the HomeBrew installation directory (I believe).

On the PIP installation method:

pip is automatically installed using the python.org package, if the user does not have pip installed, the easy_install method is depreciated.


Hopefully this is helpful, happy to edit in anyway that would be useful. 
 