### PR TITLE
Add troubleshooting case

### DIFF
--- a/libraries/cs50/c.rst
+++ b/libraries/cs50/c.rst
@@ -59,6 +59,9 @@ If when compiling your program, you see:
     
     ``cannot open shared object file: No such file or directory``:
         Add ``export LD_LIBRARY_PATH=/usr/local/lib`` to your ``.bashrc``.
+        
+    ``ld: library not found for -lcrypt``:
+        Remove ``-lcrypt`` from ``LDLIBS``.
 
 
 Usage


### PR DESCRIPTION
The crypt library does not exist outside of the standard library on Mac. -lcrypt must not be added/must be removed from LDLIBS in order to successfully compile programs with make that use the cs50 library.