### PR TITLE
Fixate docutils version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-tabs==1.1.13
 sphinx_rtd_theme==0.5.2
 sphinxcontrib-httpdomain==1.7.0
 sphinxext-opengraph==0.3.1
+docutils==0.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.17
 recommonmark==0.6.0
 sphinx==3.5.4
 sphinx-autobuild==0.7.1
@@ -6,4 +7,3 @@ sphinx-tabs==1.1.13
 sphinx_rtd_theme==0.5.2
 sphinxcontrib-httpdomain==1.7.0
 sphinxext-opengraph==0.3.1
-docutils==0.17


### PR DESCRIPTION
This PR fixates the `docutils` version to 0.17.