### PR TITLE
Replace recommonmark extension with myst-parser

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -3,7 +3,7 @@ import time
 exclude_patterns = ["README.md"]
 
 extensions = [
-    "recommonmark",
+    "myst_parser",
     "sphinx_markdown_tables",
     "sphinx_tabs.tabs",
     "sphinxcontrib.httpdomain",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-recommonmark==0.6.0
+myst-parser==0.15.1
 sphinx==4.0.0
 sphinx-markdown-tables==0.0.15
 sphinx-tabs==3.1.0


### PR DESCRIPTION
This PR addresses #114 which will migrate migrate from recommonmark to myst-parser, since the former is deprecated: [https://github.com/readthedocs/recommonmark/issues/221](https://github.com/readthedocs/recommonmark/issues/221)