### PR TITLE
Made ssh authentication the last step

### DIFF
--- a/github.md
+++ b/github.md
@@ -7,7 +7,6 @@ But you can still use `check50` and `submit50`! You just need to log in a bit di
 ## SSH
 
 1. Open a terminal window (as in CS50 IDE).
-1. Execute `ssh -p443 -T git@ssh.github.com`. If asked whether you're "sure you want to continue connecting," input `yes`, then hit Enter.
 1. Execute `ssh-keygen`. When prompted to "save the key," just hit Enter, without typing anything.
 1. You'll then be prompted for a "passphrase" (i.e., password). If you only use your GitHub account for CS50, no need to input a passphrase; just hit Enter. Otherwise, input a passphrase (that you won't forget!), then hit Enter, then input it again, then hit Enter again. For security's sake, you won't see what you type. You'll then see a "randomart image" that you can ignore.
 1. Execute `cat ~/.ssh/id_rsa.pub`. You'll then see your "public key," multiple lines of seemingly random text. Highlight and copy all of those lines, from `ssh-rsa` to the end. **But don't highlight your terminal window's prompts (which contain `$`) before or after those lines.**
@@ -15,6 +14,7 @@ But you can still use `check50` and `submit50`! You just need to log in a bit di
 1. Click **New SSH Key**.
 1. Paste your public key into the text box under **Key**. Optionally input a title under **Title** (e.g., `CS50 IDE` if using CS50 IDE).
 1. Click **Add SSH Key**.
+1. Back to the terminal window (as in CS50 IDE), execute `ssh -p443 -T git@ssh.github.com`. If asked whether you're "sure you want to continue connecting," input `yes`, then hit Enter.
 
 You should now be able to use `check50` and `submit50` (and `git`) without GitHub username and password. But if you created a passphrase, you might still be prompted for that.
 


### PR DESCRIPTION
It seems that `ssh -p443 -T git@ssh.github.com` should be the last step in SSH configuration. Students can verify if they have successfully configured SSH with GitHub and add the GitHub server as a known host through that process.