### PR TITLE
Remote-Containers => Dev Containers

### DIFF
--- a/code.md
+++ b/code.md
@@ -82,10 +82,10 @@ To use VS Code locally with Docker, running a [codespace-like container](https:/
 1. Download CS50's latest `.devcontainer.json` file from [raw.githubusercontent.com/cs50/codespace/main/.devcontainer.json](https://raw.githubusercontent.com/cs50/codespace/main/.devcontainer.json), saving it in `foo`. Because the file's name starts with a dot (i.e., period), it might seem to "disappear" when you download it. But, in a terminal window on Linux or macOS, you should see it with `ls -a`, and at a command prompt in Windows, you should see it with `dir /a`.
 1. Download, install, and start [Docker](/docker/) on your computer.
 1. Download and install [VS Code](https://code.visualstudio.com/download) itself on your computer.
-1. Install VS Code's [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
-1. Open VS Code's [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette), as via **Ctrl+Shift+P** on Linux, **⇧⌘P** on macOS, and **Ctrl+Shift+P** on Windows, select **>Remote-Containers - Open Folder in Container...**, and open `foo`.
+1. Install VS Code's [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
+1. Open VS Code's [command palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette), as via **Ctrl+Shift+P** on Linux, **⇧⌘P** on macOS, and **Ctrl+Shift+P** on Windows, select **>Dev Containers - Open Folder in Container...**, and open `foo`.
 
-Alternatively, select **>Remote-Containers: Install devcontainer CLI**, and then, in VS Code's terminal window, `cd` to `foo` and execute `devcontainer open .`.
+Alternatively, select **>Dev Containers: Install devcontainer CLI**, and then, in VS Code's terminal window, `cd` to `foo` and execute `devcontainer open .`.
 
 Once the container finishes building and starting, you should find that `foo` is mounted within the container at `/workspaces/foo`.
 


### PR DESCRIPTION
Looks like VSC's remote-containers extension rebranded to "Dev Containers". Updated the readme to reflect this. 

https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers now links to an extension named Dev Containers

While it used to link to remote-containers as per below:

https://web.archive.org/web/20220713192545/https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers

Stumbled upon this as the option

* select **>Remote-Containers - Open Folder in Container...**

no longer exists. Instead it's:

* **>Dev Containers - Open Folder in Container...**